### PR TITLE
PreferredName semantic equals

### DIFF
--- a/student-preferred-name-portlet-api/src/main/java/edu/wisc/portlet/preferred/form/PreferredName.java
+++ b/student-preferred-name-portlet-api/src/main/java/edu/wisc/portlet/preferred/form/PreferredName.java
@@ -4,6 +4,7 @@ import java.io.Serializable;
 
 import org.apache.commons.lang.builder.EqualsBuilder;
 import org.apache.commons.lang.builder.HashCodeBuilder;
+import org.apache.commons.lang.builder.ToStringBuilder;
 
 public class PreferredName implements Serializable {
     private static final long serialVersionUID = 2L;
@@ -103,5 +104,18 @@ public class PreferredName implements Serializable {
         return new HashCodeBuilder(262444801, 597203845).appendSuper(super.hashCode())
             .append(this.middleName).append(this.lastName).append(this.hideSource)
             .append(this.firstName).append(this.pvi).toHashCode();
+    }
+
+    /**
+     * @see java.lang.Object#toString()
+     */
+    public String toString() {
+        return new ToStringBuilder(this)
+            .append("firstName", this.firstName)
+            .append("middleName", this.middleName)
+            .append("lastName", this.lastName)
+            .append("pvi", this.pvi)
+            .append("hideSource", this.hideSource)
+            .toString();
     }
 }

--- a/student-preferred-name-portlet-api/src/main/java/edu/wisc/portlet/preferred/form/PreferredName.java
+++ b/student-preferred-name-portlet-api/src/main/java/edu/wisc/portlet/preferred/form/PreferredName.java
@@ -7,7 +7,7 @@ import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.apache.commons.lang.builder.ToStringBuilder;
 
 public class PreferredName implements Serializable {
-    private static final long serialVersionUID = 2L;
+    private static final long serialVersionUID = 3L;
 
     private String firstName;
 
@@ -91,7 +91,7 @@ public class PreferredName implements Serializable {
             return false;
         }
         PreferredName rhs = (PreferredName) object;
-        return new EqualsBuilder().appendSuper(super.equals(object))
+        return new EqualsBuilder()
             .append(this.middleName, rhs.middleName).append(this.lastName, rhs.lastName)
             .append(this.hideSource, rhs.hideSource).append(this.firstName, rhs.firstName)
             .append(this.pvi, rhs.pvi).isEquals();
@@ -101,7 +101,7 @@ public class PreferredName implements Serializable {
      * @see java.lang.Object#hashCode()
      */
     public int hashCode() {
-        return new HashCodeBuilder(262444801, 597203845).appendSuper(super.hashCode())
+        return new HashCodeBuilder(262444801, 597203845)
             .append(this.middleName).append(this.lastName).append(this.hideSource)
             .append(this.firstName).append(this.pvi).toHashCode();
     }

--- a/student-preferred-name-portlet-api/src/test/java/edu/wisc/portlet/preferred/form/PreferredNameTest.java
+++ b/student-preferred-name-portlet-api/src/test/java/edu/wisc/portlet/preferred/form/PreferredNameTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package edu.wisc.portlet.preferred.form;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * Unit tests for PreferredName.
+ *
+ * @since StudentPreferredNamePortlet v 1.0.7
+ */
+public class PreferredNameTest {
+
+    /**
+     * Test that two PreferredName s with identical semantic content are considered equal.
+     */
+    @Test
+    public void testSemanticEquals() {
+
+        final PreferredName timOne = new PreferredName();
+        final PreferredName timTwo = new PreferredName();
+
+        timOne.setFirstName("Timothy");
+        timTwo.setFirstName("Timothy");
+
+        timOne.setMiddleName("Elliott");
+        timTwo.setMiddleName("Elliott");
+
+        timOne.setLastName("Levett");
+        timTwo.setLastName("Levett");
+
+        timOne.setPvi("a_pvi_value");
+        timTwo.setPvi("a_pvi_value");
+
+        timOne.setHideSource(true);
+        timTwo.setHideSource(true);
+
+        assertEquals(timOne, timTwo);
+        assertEquals(timOne.hashCode(), timTwo.hashCode());
+    }
+
+    /**
+     * Test that new, blank instances of PreferredName are equal.
+     */
+    @Test
+    public void testNewInstancesAreEqual() {
+
+        final PreferredName nameOne = new PreferredName();
+        final PreferredName nameTwo = new PreferredName();
+
+        assertEquals(nameOne.hashCode(), nameTwo.hashCode());
+        assertEquals(nameOne, nameTwo);
+
+    }
+}


### PR DESCRIPTION
Stops considering `super().equals()` / `super().hashCode()` in computing `PreferredName` equality and hash code.

The superclass is `Object`.  Considering its concept of equality reduces `PreferredName` equality to reference identity, but the more useful (and intended) concept is semantic equality, that is, a `PreferredName` that *means* the same preferences about names.

(`PreferredName` not implementing semantic equality turns out to be annoying if you naively try to add some unit tests, which is what this changeset is a step towards.)

Also, adds a `toString()`, which is useful in troubleshooting this.