### PR TITLE
Test PreferredNameService handling null preferred names

### DIFF
--- a/student-preferred-name-portlet-api/src/main/java/edu/wisc/portlet/preferred/service/PreferredNameService.java
+++ b/student-preferred-name-portlet-api/src/main/java/edu/wisc/portlet/preferred/service/PreferredNameService.java
@@ -15,6 +15,17 @@ public interface PreferredNameService {
      */
     public PreferredName getPreferredName(String pvi);
 
+    /**
+     * Get the name preference for the person identified by the given pvi,
+     * given a known last name of record for the person.
+     *
+     * If the user has no name preference,
+     * returns a PreferredName object preferring the last name of record.
+     *
+     * @param pvi
+     * @param legalLastName
+     * @return a PreferredName .  will not return null.
+     */
     public PreferredName getPreferredName(String pvi, String legalLastName);
 
     public PreferredNameExtended getPreferredNameAndLegalName(String pvi);

--- a/student-preferred-name-portlet-api/src/main/java/edu/wisc/portlet/preferred/service/PreferredNameService.java
+++ b/student-preferred-name-portlet-api/src/main/java/edu/wisc/portlet/preferred/service/PreferredNameService.java
@@ -4,6 +4,15 @@ import edu.wisc.portlet.preferred.form.PreferredName;
 import edu.wisc.portlet.preferred.form.PreferredNameExtended;
 
 public interface PreferredNameService {
+
+    /**
+     * Get the name preference for the person identified by the given pvi.
+     *
+     * If the user has no name preference, returns an unpopulated PreferredName object.
+     *
+     * @param pvi
+     * @return a PreferredName object, whether the user prefers or not. Does not return null.
+     */
     public PreferredName getPreferredName(String pvi);
 
     public PreferredName getPreferredName(String pvi, String legalLastName);

--- a/student-preferred-name-portlet-webapp/pom.xml
+++ b/student-preferred-name-portlet-webapp/pom.xml
@@ -177,6 +177,11 @@
         
 
         <!-- ===== Test Dependencies ====================================== -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.9.5</version>
+        </dependency>
         
     </dependencies>
     

--- a/student-preferred-name-portlet-webapp/src/test/java/edu/wisc/portlet/preferred/service/PreferredNameServiceImplTest.java
+++ b/student-preferred-name-portlet-webapp/src/test/java/edu/wisc/portlet/preferred/service/PreferredNameServiceImplTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to Apereo under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work
+ * for additional information regarding copyright ownership.
+ * Apereo licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License.  You may obtain a
+ * copy of the License at the following location:
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package edu.wisc.portlet.preferred.service;
+
+import edu.wisc.portlet.preferred.dao.PreferredNameDao;
+import edu.wisc.portlet.preferred.form.PreferredName;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+/**
+ * Unit test for PreferredNameServiceImpl.
+ */
+public class PreferredNameServiceImplTest {
+
+    private PreferredNameServiceImpl serviceImpl;
+
+    @Mock
+    private PreferredNameDao preferredNameDao;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        serviceImpl = new PreferredNameServiceImpl();
+        serviceImpl.setPreferredNameDao(preferredNameDao);
+    }
+
+
+    /**
+     * Test that the service represents the preferred name of a user
+     * for whom the underlying DAO reports no preferred name as having an unpopulated preferred
+     * name object.
+     */
+    @Test
+    public void noPreferredNameRepresentedAsPreferredName() {
+
+        when(preferredNameDao.getPreferredName("some_pvi")).thenReturn(null);
+
+        final PreferredName returnedPreferredName = serviceImpl.getPreferredName("some_pvi");
+
+        assertEquals(new PreferredName(), returnedPreferredName);
+
+
+    }
+
+}

--- a/student-preferred-name-portlet-webapp/src/test/java/edu/wisc/portlet/preferred/service/PreferredNameServiceImplTest.java
+++ b/student-preferred-name-portlet-webapp/src/test/java/edu/wisc/portlet/preferred/service/PreferredNameServiceImplTest.java
@@ -61,7 +61,24 @@ public class PreferredNameServiceImplTest {
 
         assertEquals(new PreferredName(), returnedPreferredName);
 
+    }
 
+    /**
+     * Test that the service represents the preferred name of a user for whom the underlying DAO
+     * reports no preferred name as preferring his or her actual last name.
+     */
+    @Test
+    public void noPreferredNameWithLastNameRepresentedAsPreferredName() {
+
+        when(preferredNameDao.getPreferredName("some_other_pvi")).thenReturn(null);
+
+        final PreferredName returnedPreferredName =
+            serviceImpl.getPreferredName("some_other_pvi", "PETRO");
+
+        final PreferredName expectedPreferredName = new PreferredName();
+        expectedPreferredName.setLastName("PETRO");
+
+        assertEquals(expectedPreferredName, returnedPreferredName);
     }
 
 }


### PR DESCRIPTION
Unit tests (and JavaDoc) for how PreferredNameService handles the underlying DAO reporting no name preference.